### PR TITLE
Settings switch

### DIFF
--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -1,4 +1,23 @@
 #Requires -Version 5
+Param
+(
+    [switch] $Settings
+)
+
+# Check for settings directory and create it if none exists
+$script:SettingsPath = Join-Path $env:LOCALAPPDATA -ChildPath 'YamlCreate'
+if (!(Test-Path $script:SettingsPath)) { New-Item -ItemType 'Directory' -Force -Path $script:SettingsPath | Out-Null }
+# Check for settings file and create it if none exists
+$script:SettingsPath = $(Join-Path $script:SettingsPath -ChildPath 'Settings.yaml')
+if (!(Test-Path $script:SettingsPath)) { '# See https://github.com/microsoft/winget-pkgs/tree/master/doc/tools/YamlCreate.md for a list of available settings' > $script:SettingsPath }
+# Load settings from file
+$ScriptSettings = ConvertFrom-Yaml -Yaml ($(Get-Content -Path $script:SettingsPath -Encoding UTF8) -join "`n")
+
+if ($Settings) {
+    Invoke-Item -Path $script:SettingsPath
+    exit
+}
+
 $ScriptHeader = '# Created with YamlCreate.ps1 v2.0.0'
 $ManifestVersion = '1.0.0'
 $PSDefaultParameterValues = @{ '*:Encoding' = 'UTF8' }
@@ -55,15 +74,6 @@ try {
     Write-Host 'Error downloading schemas. Please run the script again.' -ForegroundColor Red
     exit 1
 }
-
-# Check for settings directory and create it if none exists
-$script:SettingsPath = Join-Path $env:LOCALAPPDATA -ChildPath 'YamlCreate'
-if (!(Test-Path $script:SettingsPath)) { New-Item -ItemType 'Directory' -Force -Path $script:SettingsPath | Out-Null }
-# Check for settings file and create it if none exists
-$script:SettingsPath = $(Join-Path $script:SettingsPath -ChildPath 'Settings.yaml')
-if (!(Test-Path $script:SettingsPath)) { '# See https://github.com/microsoft/winget-pkgs/tree/master/doc/tools/YamlCreate.md for a list of available settings' > $script:SettingsPath }
-# Load settings from file
-$ScriptSettings = ConvertFrom-Yaml -Yaml ($(Get-Content -Path $script:SettingsPath -Encoding UTF8) -join "`n")
 
 filter TrimString {
     $_.Trim()

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -2,12 +2,21 @@
 Param
 (
     [switch] $Settings,
+    [switch] $help,
     [Parameter(Mandatory = $false)]
     [string] $PackageIdentifier,
     [Parameter(Mandatory = $false)]
     [string] $PackageVersion
     
 )
+
+if ($help) {
+    Write-Host -ForegroundColor 'Green' "For full documentation of the script, see https://github.com/microsoft/winget-pkgs/tree/master/doc/tools/YamlCreate.md"
+    Write-Host -ForegroundColor 'Yellow' 'Usage: ' -NoNewline
+    Write-Host -ForegroundColor 'White' '.\YamlCreate.ps1 [-PackageIdentifier <identifier>] [-PackageVersion <version>] [-Settings]'
+    Write-Host
+    exit
+}
 
 # Check for settings directory and create it if none exists
 $script:SettingsPath = Join-Path $env:LOCALAPPDATA -ChildPath 'YamlCreate'

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -1432,7 +1432,7 @@ Function Enter-PR-Parameters {
                         Write-Host -ForegroundColor 'Red' "Invalid Issue: $i"
                         continue
                     }
-                    $PrBodyContentReply += @("- Resolves #$i")
+                    $PrBodyContentReply += @("* Resolves #$i")
                 }
             }
         }

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -1,7 +1,12 @@
 #Requires -Version 5
 Param
 (
-    [switch] $Settings
+    [switch] $Settings,
+    [Parameter(Mandatory = $false)]
+    [string] $PackageIdentifier,
+    [Parameter(Mandatory = $false)]
+    [string] $PackageVersion
+    
 )
 
 # Check for settings directory and create it if none exists
@@ -1737,11 +1742,13 @@ Write-Host
 
 # Request Package Identifier and Validate
 do {
-    Write-Host -ForegroundColor 'Red' $script:_returnValue.ErrorString()
-    Write-Host -ForegroundColor 'Green' -Object '[Required] Enter the Package Identifier, in the following format <Publisher shortname.Application shortname>. For example: Microsoft.Excel'
-    $script:PackageIdentifier = Read-Host -Prompt 'PackageIdentifier' | TrimString
-    $PackageIdentifierFolder = $PackageIdentifier.Replace('.', '\')
+    if ((String.Validate $PackageIdentifier -IsNull) -or ($script:_returnValue.StatusCode -ne [ReturnValue]::Success().StatusCode)) {
+        Write-Host -ForegroundColor 'Red' $script:_returnValue.ErrorString()
+        Write-Host -ForegroundColor 'Green' -Object '[Required] Enter the Package Identifier, in the following format <Publisher shortname.Application shortname>. For example: Microsoft.Excel'
+        $script:PackageIdentifier = Read-Host -Prompt 'PackageIdentifier' | TrimString
+    }
 
+    $PackageIdentifierFolder = $PackageIdentifier.Replace('.', '\')
     if (String.Validate $PackageIdentifier -MinLength 4 -MaxLength $Patterns.IdentifierMaxLength -MatchPattern $Patterns.PackageIdentifier) {
         $script:_returnValue = [ReturnValue]::Success()
     } else {
@@ -1757,10 +1764,11 @@ do {
 
 # Request Package Version and Validate
 do {
-    Write-Host -ForegroundColor 'Red' $script:_returnValue.ErrorString()
-    Write-Host -ForegroundColor 'Green' -Object '[Required] Enter the version. for example: 1.33.7'
-    $script:PackageVersion = Read-Host -Prompt 'Version' | TrimString
-
+    if ((String.Validate $PackageVersion -IsNull) -or ($script:_returnValue.StatusCode -ne [ReturnValue]::Success().StatusCode)) {
+        Write-Host -ForegroundColor 'Red' $script:_returnValue.ErrorString()
+        Write-Host -ForegroundColor 'Green' -Object '[Required] Enter the version. for example: 1.33.7'
+        $script:PackageVersion = Read-Host -Prompt 'Version' | TrimString
+    }
     if (String.Validate $PackageVersion -MaxLength $Patterns.VersionMaxLength -MatchPattern $Patterns.PackageVersion -NotNull) {
         $script:_returnValue = [ReturnValue]::Success()
     } else {

--- a/doc/tools/YamlCreate.md
+++ b/doc/tools/YamlCreate.md
@@ -22,7 +22,7 @@ When running YamlCreate through the command line, you can specify additional arg
 `.\YamlCreate.ps1 [-PackageIdentifier <identifier>] [-PackageVersion <version>] [-Settings]`
 
 # YamlCreate Settings
-YamlCreate offers a few settings to customize your manifest creation experience. The settings file is found in your local appdata folder under `YamlCreate`. It is empty by default, but you can copy the sample below which describes what all of the available options are; or, you can enter just specific keys as you see fit.
+YamlCreate offers a few settings to customize your manifest creation experience. The settings file is found in the `%LOCALAPPDATA%\YamlCreate` folder. It is empty by default, but you can copy the sample below which describes what all of the available options are; or, you can enter just specific keys as you see fit.
 ```yaml
 # This setting allows you to set a default action for whether or not to test your manifest in windows sandbox
     # always - Always tests manifests

--- a/doc/tools/YamlCreate.md
+++ b/doc/tools/YamlCreate.md
@@ -16,6 +16,11 @@ The script can automatically create commits and branches within your fork of the
 ## GitHub CLI
 If you have Git installed, you can also create the pull request for your manifest directly from the script. You will have to install the GitHub CLI and authorize it with your GitHub Account. Again, winget makes installing the CLI easy. Open up PowerShell and install the GitHub CLI using `winget install GitHub.CLI`. Once the CLI is installed, close, then re-open PowerShell. To log in and authorize the CLI, run the command `gh auth login`. Follow the prompts that appear to finish the authorization.
 
+# Command Line Arguments
+When running YamlCreate through the command line, you can specify additional arguments such as the package identifier or the package version. You can also use the settings switch to open the settings file. More information on the available settings is below.
+
+`.\YamlCreate.ps1 [-PackageIdentifier <identifier>] [-PackageVersion <version>] [-Settings]`
+
 # YamlCreate Settings
 YamlCreate offers a few settings to customize your manifest creation experience. The settings file is found in your local appdata folder under `YamlCreate`. It is empty by default, but you can copy the sample below which describes what all of the available options are; or, you can enter just specific keys as you see fit.
 ```yaml


### PR DESCRIPTION
* `.\YamlCreate.ps1 -Settings` now opens the settings file
* `.\YamlCreate.ps1 -Settings` now shows a link to the documentation and command line usage for YamlCreate
* `.\YamlCreate.ps1 -PackageIdentifier <identifier>` can be used to skip the package identifier prompt
* `.\YamlCreate.ps1 -PackageVersion <version>` can be used to skip the package version prompt
* `.\YamlCreate.ps1 -PackageIdentifier <identifier> -PackageVersion <version>` can be used to skip both the package identifier and package version prompt

-----
* Resolves #47 