### PR TITLE
Use Unique Branch Names

### DIFF
--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -1646,7 +1646,7 @@ Function Write-Locale-Manifests {
 
     # Create the folder for the file if it doesn't exist
     New-Item -ItemType 'Directory' -Force -Path $AppFolder | Out-Null
-    $LocaleManifestPath = $AppFolder + "\$PackageIdentifier" + '.locale.' + "$PackageLocale" + '.yaml'
+    $script:LocaleManifestPath = $AppFolder + "\$PackageIdentifier" + '.locale.' + "$PackageLocale" + '.yaml'
 
     # Write the manifest to the file
     $ScriptHeader + "$(GetDebugString)`n$yamlServer`n" > $LocaleManifestPath
@@ -2180,11 +2180,11 @@ if ($PromptSubmit -eq '0') {
     git fetch upstream master --quiet
     git switch -d upstream/master       
     if ($LASTEXITCODE -eq '0') {
+        $UniqueBranchID = $(Get-FileHash $script:LocaleManifestPath).Hash[0..6] -Join ""
         git add -A
         git commit -m "$CommitType`: $PackageIdentifier version $PackageVersion" --quiet
-
-        git switch -c "$PackageIdentifier-$PackageVersion" --quiet
-        git push --set-upstream origin "$PackageIdentifier-$PackageVersion" --quiet
+        git switch -c "$PackageIdentifier-$PackageVersion-$UniqueBranchID" --quiet
+        git push --set-upstream origin "$PackageIdentifier-$PackageVersion-$UniqueBranchID" --quiet
 
         # If the user has the cli too
         if (Get-Command 'gh.exe' -ErrorAction SilentlyContinue) {


### PR DESCRIPTION
@OfficialEsco I ran into a bug where if a user updates a manifest version, submits the PR, waits for the PR to merge, deletes the branch, and then sometime later uses the script to update the same version, it will use the same branch name and cause an error that prevents the branch from being pushed since the tip is behind the remote.

This should greatly reduce the likelihood that any branches will have the same name