### PR TITLE
Made it so git config was only modified for the local repo.

### DIFF
--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -2174,11 +2174,11 @@ if ($PromptSubmit -eq '0') {
     }
 
     # Change the users git configuration to suppress some git messages
-    $_previousConfig = git config --global --get core.safecrlf
+    $_previousConfig = git config --get core.safecrlf
     if ($_previousConfig) {
-        git config --global --replace core.safecrlf false
+        git config --replace core.safecrlf false
     } else {
-        git config --global --add core.safecrlf false
+        git config --add core.safecrlf false
     }
 
     # Fetch the upstream branch, create a commit onto the detached head, and push it to a new branch


### PR DESCRIPTION
cc @Trenly @vedantmgoyal2009 @OfficialEsco 

I saw this and it bothered me, because we shouldn't be modifying peoples global .gitconfig. So I removed that flag.

It works fine, although I don't know why we need to mess with `core.autocrlf` at all. @vedantmgoyal2009, what warning were you trying to suppress?