### PR TITLE
Check for productcode even if extension doesn't match

### DIFF
--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -539,7 +539,7 @@ Function Read-InstallerEntry {
                 if ($_) { $_Installer['InstallerType'] = $_ | Select-Object -First 1 }
                 Get-UriArchitecture -URI $_Installer['InstallerUrl'] -OutVariable _ | Out-Null
                 if ($_) { $_Installer['Architecture'] = $_ | Select-Object -First 1 }
-                if ([System.Environment]::OSVersion.Platform -match 'Win' -and ($script:dest).EndsWith('.msi')) {
+                if ([System.Environment]::OSVersion.Platform -match 'Win' -and ($script:dest).EndsWith('.msi') -or ($_Installer.InstallerType -in @('msi';'wix'))) {
                     $ProductCode = ([string](Get-MSIProperty -MSIPath $script:dest -Parameter 'ProductCode') | Select-String -Pattern '{[A-Z0-9]{8}-([A-Z0-9]{4}-){3}[A-Z0-9]{12}}').Matches.Value
                 }
                 if (Test-String -Not "$ProductCode" -IsNull) { $_Installer['ProductCode'] = "$ProductCode" }
@@ -894,7 +894,7 @@ Function Read-QuickInstallerEntry {
                 # Update the product code, if a new one exists
                 # If a new product code doesn't exist, and the installer isn't an `.exe` file, remove the product code if it exists
                 $MSIProductCode = $null
-                if ([System.Environment]::OSVersion.Platform -match 'Win' -and ($script:dest).EndsWith('.msi')) {
+                if ([System.Environment]::OSVersion.Platform -match 'Win' -and ($script:dest).EndsWith('.msi') -or ($_NewInstaller.InstallerType -in @('msi';'wix'))) {
                     $MSIProductCode = ([string](Get-MSIProperty -MSIPath $script:dest -Parameter 'ProductCode') | Select-String -Pattern '{[A-Z0-9]{8}-([A-Z0-9]{4}-){3}[A-Z0-9]{12}}').Matches.Value
                 }
                 if (Test-String -not $MSIProductCode -IsNull) {
@@ -2304,7 +2304,7 @@ Switch ($script:Option) {
                 # Update the product code, if a new one exists
                 # If a new product code doesn't exist, and the installer isn't an `.exe` file, remove the product code if it exists
                 $MSIProductCode = $null
-                if ([System.Environment]::OSVersion.Platform -match 'Win' -and ($script:dest).EndsWith('.msi')) {
+                if ([System.Environment]::OSVersion.Platform -match 'Win' -and ($script:dest).EndsWith('.msi') -or ($_Installer.InstallerType -in @('msi';'wix'))) {
                     $MSIProductCode = ([string](Get-MSIProperty -MSIPath $script:dest -Parameter 'ProductCode') | Select-String -Pattern '{[A-Z0-9]{8}-([A-Z0-9]{4}-){3}[A-Z0-9]{12}}').Matches.Value
                 }
                 if (Test-String -not $MSIProductCode -IsNull) {

--- a/Tools/YamlCreate.ps1
+++ b/Tools/YamlCreate.ps1
@@ -539,7 +539,7 @@ Function Read-InstallerEntry {
                 if ($_) { $_Installer['InstallerType'] = $_ | Select-Object -First 1 }
                 Get-UriArchitecture -URI $_Installer['InstallerUrl'] -OutVariable _ | Out-Null
                 if ($_) { $_Installer['Architecture'] = $_ | Select-Object -First 1 }
-                if ([System.Environment]::OSVersion.Platform -match 'Win' -and ($script:dest).EndsWith('.msi') -or ($_Installer.InstallerType -in @('msi';'wix'))) {
+                if ([System.Environment]::OSVersion.Platform -match 'Win' -and (($script:dest).EndsWith('.msi') -or ($_Installer.InstallerType -in @('msi';'wix')))) {
                     $ProductCode = ([string](Get-MSIProperty -MSIPath $script:dest -Parameter 'ProductCode') | Select-String -Pattern '{[A-Z0-9]{8}-([A-Z0-9]{4}-){3}[A-Z0-9]{12}}').Matches.Value
                 }
                 if (Test-String -Not "$ProductCode" -IsNull) { $_Installer['ProductCode'] = "$ProductCode" }
@@ -894,7 +894,7 @@ Function Read-QuickInstallerEntry {
                 # Update the product code, if a new one exists
                 # If a new product code doesn't exist, and the installer isn't an `.exe` file, remove the product code if it exists
                 $MSIProductCode = $null
-                if ([System.Environment]::OSVersion.Platform -match 'Win' -and ($script:dest).EndsWith('.msi') -or ($_NewInstaller.InstallerType -in @('msi';'wix'))) {
+                if ([System.Environment]::OSVersion.Platform -match 'Win' -and (($script:dest).EndsWith('.msi') -or $_NewInstaller.InstallerType -in @('msi';'wix'))) {
                     $MSIProductCode = ([string](Get-MSIProperty -MSIPath $script:dest -Parameter 'ProductCode') | Select-String -Pattern '{[A-Z0-9]{8}-([A-Z0-9]{4}-){3}[A-Z0-9]{12}}').Matches.Value
                 }
                 if (Test-String -not $MSIProductCode -IsNull) {
@@ -2304,7 +2304,7 @@ Switch ($script:Option) {
                 # Update the product code, if a new one exists
                 # If a new product code doesn't exist, and the installer isn't an `.exe` file, remove the product code if it exists
                 $MSIProductCode = $null
-                if ([System.Environment]::OSVersion.Platform -match 'Win' -and ($script:dest).EndsWith('.msi') -or ($_Installer.InstallerType -in @('msi';'wix'))) {
+                if ([System.Environment]::OSVersion.Platform -match 'Win' -and (($script:dest).EndsWith('.msi') -or $_Installer.InstallerType -in @('msi';'wix'))) {
                     $MSIProductCode = ([string](Get-MSIProperty -MSIPath $script:dest -Parameter 'ProductCode') | Select-String -Pattern '{[A-Z0-9]{8}-([A-Z0-9]{4}-){3}[A-Z0-9]{12}}').Matches.Value
                 }
                 if (Test-String -not $MSIProductCode -IsNull) {


### PR DESCRIPTION
* Closes #150
@OfficialEsco This should do what you wanted, but I will warn you that if the installer type is MSI or WIX and the file that is downloaded is not truly an MSI file then it will likely error out.  The more intelligent that we try to make things, the bigger the chance that incorrect input will cause things to go 💥  
